### PR TITLE
ASK - Create "strings" package to support future i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "commander": "^10.0.0",
-    "exceljs": "^4.3.0"
+    "exceljs": "^4.3.0",
+    "i18next": "^22.4.14"
   }
 }

--- a/src/strings/ca.ts
+++ b/src/strings/ca.ts
@@ -1,0 +1,6 @@
+export default {
+  translation: {
+    compensation: "Stock Appreciation Rights",
+    taxes: "45-day election",
+  },
+};

--- a/src/strings/i18next.ts
+++ b/src/strings/i18next.ts
@@ -1,0 +1,13 @@
+import i18next from "i18next";
+import us from "./us";
+import ca from "./ca";
+
+i18next.init({
+  lng: "en-US",
+  resources: {
+    "en-US": us,
+    "en-CA": ca,
+  },
+});
+
+export default i18next;

--- a/src/strings/us.ts
+++ b/src/strings/us.ts
@@ -1,0 +1,6 @@
+export default {
+  translation: {
+    compensation: "Stock Options",
+    taxes: "83(b) election",
+  },
+};

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, beforeAll } from "@jest/globals";
+import i18next from "i18next";
+import us from "../src/strings/us";
+import ca from "../src/strings/ca";
+
+describe("translations", () => {
+  beforeAll(() => {
+    i18next.init({
+      lng: "en-US",
+      resources: {
+        "en-US": us,
+        "en-CA": ca,
+      },
+    });
+  });
+
+  test("loads US translations", () => {
+    expect(i18next.t("compensation")).toEqual("Stock Options");
+  });
+
+  test("loads Canada translations", () => {
+    i18next.changeLanguage("en-CA");
+    expect(i18next.t("compensation")).toEqual("Stock Appreciation Rights");
+  });
+});


### PR DESCRIPTION
For this task, I thought about the [i18next](i18next.com) package.
I added some dummy strings in the US and Canadian companies' "translation" files (us.js and ca.js)